### PR TITLE
Fix response variable name in prediction endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,7 +40,7 @@ def predict():
 
         modelRes = jsonify({"result":result})
         modelRes.headers['Content-Type']='application/json; charset=utf-8'
-        return modelRess
+        return modelRes
 
 if __name__ == '__main__':
     print("Your model server running successfully!")


### PR DESCRIPTION
## Summary
- fix typo causing NameError when returning prediction result

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68a7b09290b883208154ccdc31d55994